### PR TITLE
Add recoveryEmail field with Berkeley Email to recover HKN Gmail

### DIFF
--- a/hknlib/election/users.py
+++ b/hknlib/election/users.py
@@ -54,6 +54,7 @@ class User:
                 },
             ],
             "changePasswordAtNextLogin": True,
+            "recoveryEmail": self.secondary_email,
         }
 
 


### PR DESCRIPTION
PR to add the recovery email field

However, due to the Berkeley Email non-Alumni policy, it is advised a Personal Email (not Berkeley) is collected in the Google Forms and the code is changed accordingly to add that recovery info to the recoveryEmail field

For initial creation, it is recommended to still send to Berkeley email as an initial sanity check way to make sure account is sent to a Berkeley student
